### PR TITLE
WINDUPRULE-429 Some enhancementes to the rule

### DIFF
--- a/rules-reviewed/camel3/camel2/tests/data/xml-renamed-components/pom.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-renamed-components/pom.xml
@@ -11,6 +11,10 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-http4</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-rxjava2</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0"?>
 <ruletest id="xml-moved-components-tests"
-		xmlns="http://windup.jboss.org/schema/jboss-ruleset"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
-	<testDataPath>data/xml-moved-components</testDataPath>
-	<rulePath>../xml-moved-components.windup.xml</rulePath>
-	<ruleset>
-		<rules>
-			<rule id="xml-moved-components-00000-test">
-				<when>
-					<not>
-						<iterable-filter size="1">
-							<hint-exists message="`camel-xslt` component has been moved from `camel-core` to separate artifact `org.apache.camel:camel-xslt`"/>
-						</iterable-filter>
-					</not>
-				</when>
-				<perform>
-					<fail message="[xml-moved-components] 'camel-xslt' dependency moved hint was not found!" />
-				</perform>
-			</rule>
-		</rules>
-	</ruleset>
+          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/xml-moved-components</testDataPath>
+    <rulePath>../xml-moved-components.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="xml-moved-components-00000-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="`camel-xslt` component has been moved from `camel-core` to separate artifact `org.apache.camel:camel-xslt`"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] 'camel-xslt' dependency moved hint was not found!" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
 </ruletest>

--- a/rules-reviewed/camel3/camel2/tests/xml-renamed-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-renamed-components.windup.test.xml
@@ -18,6 +18,18 @@
                     <fail message="[xml-renamed-components] 'camel-http4' dependency moved hint was not found!" />
                 </perform>
             </rule>
+            <rule id="xml-renamed-components-00001-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="`org.apache.camel:camel-rxjava2` artifact has been renamed in Apache Camel 3 to `org.apache.camel:camel-rxjava` artifact"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-renamed-components] 'camel-rxjava2' dependency moved hint was not found!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -15,20 +15,25 @@
 	<rules>
 		<rule id="xml-moved-components-00000">
 			<when>
+				<xmlfile as="dependencies-block" matches="/m:project/m:dependencies" in="pom.xml">
+					<namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+				</xmlfile>
+				<xmlfile matches="//*/c:camelContext/c:route/c:to[starts-with(@uri,'xslt:')]">
+					<namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
+				</xmlfile>
 				<not>
 					<project>
 						<artifact groupId="org.apache.camel" artifactId="camel-xslt"/>
 					</project>
 				</not>
-					<and>
-					<filecontent pattern="xslt:" filename="{*}.xml"/>
-				</and>
 			</when>
 			<perform>
-				<hint title="`camel-xslt` component has been moved from `camel-core` to separate artifact `org.apache.camel:camel-xslt`" effort="1" category-id="mandatory">
-					<message>`camel-xslt` component has been moved from `camel-core` to separate artifact `org.apache.camel:camel-xslt`</message>
-					<link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_xslt" title="XSTL Migration"></link>
-				</hint>
+				<iteration over="dependencies-block">
+					<hint title="`camel-xslt` component has been move" effort="1" category-id="mandatory">
+						<message>`camel-xslt` component has been moved from `camel-core` to separate artifact `org.apache.camel:camel-xslt` that has to be added as a dependency to your project pom.xml file</message>
+						<link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_xslt" title="Camel 3 - Migration Guide: XSTL Migration" />
+					</hint>
+				</iteration>
 			</perform>
 		</rule>
 	</rules>

--- a/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
@@ -21,6 +21,7 @@
             <perform>
                 <hint title="`org.apache.camel:camel-linkedin` artifact has been removed" effort="7" category-id="mandatory" >
                     <message>`org.apache.camel:camel-linkedin` artifact has been removed in Apache Camel 3 so it won't be available</message>
+                    <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_removed_components" title="Camel 3 - Migration Guide: Removed components" />
                 </hint>
             </perform>
         </rule>

--- a/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
@@ -21,6 +21,7 @@
             <perform>
                 <hint title="`org.apache.camel:camel-http4` artifact has been renamed" effort="1" category-id="mandatory" >
                     <message>`org.apache.camel:camel-http4` artifact has been renamed in Apache Camel 3 to `org.apache.camel:camel-http` artifact</message>
+                    <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_renamed_components" title="Camel 3 - Migration Guide: Renamed components" />
                     <quickfix type="REPLACE" name="camel-http4-replace">
                         <replacement>camel-http</replacement>
                         <search>camel-http4</search>

--- a/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
@@ -29,6 +29,23 @@
                 </hint>
             </perform>
         </rule>
+        <rule id="xml-renamed-components-00001">
+            <when>
+                <project>
+                    <artifact groupId="org.apache.camel" artifactId="camel-rxjava2" />
+                </project>
+            </when>
+            <perform>
+                <hint title="`org.apache.camel:camel-rxjava2` artifact has been renamed" effort="1" category-id="mandatory" >
+                    <message>`org.apache.camel:camel-rxjava2` artifact has been renamed in Apache Camel 3 to `org.apache.camel:camel-rxjava` artifact</message>
+                    <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_renamed_components" title="Camel 3 - Migration Guide: Renamed components" />
+                    <quickfix type="REPLACE" name="camel-rxjava2-replace">
+                        <replacement>camel-rxjava</replacement>
+                        <search>camel-rxjava2</search>
+                    </quickfix>
+                </hint>
+            </perform>
+        </rule>
     </rules>
 </ruleset>
 


### PR DESCRIPTION
- changed indent to be with 4 spaces (that's the default we use) just in test file. In rule file it would have make hard to see the changes so i avoid to change it but please do it
- added `<xmlfile as="dependencies-block"` to find the `<dependencies>` tag in pom.xml file because i think it's the right place for the hint about adding the dependency
- added `<xmlfile matches="//*/c:camelContext/c:route/c:to[starts-with(@uri,'xslt:')]">` condition (replacing the `filecontent` one) to have better performance in just searching for xml files using the xpath expression
- added `<iteration over="dependencies-block">` to tell the rule to apply to hint to the found `<dependencies>` tag
- changed the message to be more clear with the user (maybe too much but better safe than sorry)
- there are some other commits because i merged your PR into latest `master` branch